### PR TITLE
Upgrade petro

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -7,6 +7,7 @@ every change, see the Git log.
 Latest
 ------
 * tbd
+* Major: Upgrade to petro 12
 
 2.0.0
 -----

--- a/resolve.json
+++ b/resolve.json
@@ -17,7 +17,7 @@
         "name": "petro",
         "resolver": "git",
         "method": "semver",
-        "major": 7,
+        "major": 12,
         "sources": ["github.com/steinwurf/petro.git"]
     },
     {

--- a/src/petro_python/petro.cpp
+++ b/src/petro_python/petro.cpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <string>
 #include <vector>
+#include <system_error>
 
 #include <petro/extractor/aac_sample_extractor.hpp>
 #include <petro/extractor/avc_sample_extractor.hpp>
@@ -22,6 +23,17 @@ static PyObject* pointer_to_python(const uint8_t* data, uint32_t size)
 #else
     return PyString_FromStringAndSize((char*)data, size);
 #endif
+}
+
+template<class Extractor>
+void open(Extractor& extractor)
+{
+    std::error_code error;
+    extractor.open(error);
+    if (error)
+    {
+        throw std::system_error(error);
+    }
 }
 
 template<class Extractor>
@@ -54,9 +66,8 @@ void define_extractor_functions(ExtractorClass& extrator_class)
     using boost::python::arg;
 
     extrator_class
-    .def("open", &extractor_type::open,
-         "Open extractor.\n\n"
-         "\t:returns: True if the operation was succesful, otherwise False.\n")
+    .def("open", &open<extractor_type>,
+         "Open extractor. Throws an exception if the operation was successful.")
     .def("close", &extractor_type::close, "Close extractor.")
     .def("reset", &extractor_type::reset, "Reset extractor.")
     .def("file_path", &extractor_type::file_path,
@@ -100,7 +111,7 @@ void create_extractors()
         class_<petro::extractor::aac_sample_extractor, boost::noncopyable>(
             "AACSampleExtractor",
             "Extractor for extracting AAC samples.",
-            init<>("Extrator constructor."));
+            init<>("Extractor constructor."));
     define_extractor_functions(aac_extractor_class);
     aac_extractor_class
     .def("adts_header", &adts_header,
@@ -111,7 +122,7 @@ void create_extractors()
         class_<petro::extractor::avc_sample_extractor, boost::noncopyable>(
             "AVCSampleExtractor",
             "Extractor for extracting AVC samples.",
-            init<>("Extrator constructor."));
+            init<>("Extractor constructor."));
     define_extractor_functions(avc_extractor_class);
     avc_extractor_class
     .def("sps", &sps,

--- a/src/petro_python/petro.cpp
+++ b/src/petro_python/petro.cpp
@@ -67,7 +67,7 @@ void define_extractor_functions(ExtractorClass& extrator_class)
 
     extrator_class
     .def("open", &open<extractor_type>,
-         "Open extractor. Throws an exception if the operation was successful.")
+         "Open extractor. Throws an exception if the operation failed.")
     .def("close", &extractor_type::close, "Close extractor.")
     .def("reset", &extractor_type::reset, "Reset extractor.")
     .def("file_path", &extractor_type::file_path,

--- a/test/petro_python_tests.py
+++ b/test/petro_python_tests.py
@@ -42,7 +42,7 @@ class TestExtractH264(unittest.TestCase):
         self.assertEqual(
             mp4_file_path, extractor.file_path(), msg=mp4_file_path)
 
-        self.assertTrue(extractor.open())
+        extractor.open()
 
         self.check_sample(h264_file, extractor.sps())
         self.check_sample(h264_file, extractor.pps())
@@ -99,7 +99,7 @@ class TestExtractAAC(unittest.TestCase):
         self.assertEqual(
             mp4_file_path, extractor.file_path(), msg=mp4_file_path)
 
-        self.assertTrue(extractor.open())
+        extractor.open()
 
         self.assertFalse(extractor.at_end())
         while not extractor.at_end():


### PR DESCRIPTION
@jpihl The new error_code in the extractor.open() function gave me a bit of a headache when upgrading this project ;) I decided to throw an  `std::system_error` when an error occurs, and the user gets all information about the error:
```
Traceback (most recent call last):
  File "test\petro_python_tests.py", line 102, in test_extraction
    extractor.open()
RuntimeError: failed opening file: The system cannot find the file specified.
: iostream stream error
```
Just merge this if you like this solution (or devise something better).